### PR TITLE
Colossalg - Fix cloning (clone underlying queue)

### DIFF
--- a/src/MiddlewareQueue.php
+++ b/src/MiddlewareQueue.php
@@ -25,6 +25,14 @@ class MiddlewareQueue implements MiddlewareInterface
     }
 
     /**
+     * Copy constructor.
+     */
+    public function __clone()
+    {
+        $this->queue = clone $this->queue;
+    }
+
+    /**
      * @see MiddlewareInterface::process()
      */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface


### PR DESCRIPTION
Cloning was not cloning the underlying queue as it should have been.

This has now been fixed.